### PR TITLE
Fixed 2 issues from last PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ $(document).ready(function () {
 | **showSpeed**      | string                         | A CSS duration describing how quickly the context menu should displayed                                                                                                                  | `'0.30s'` |
 | **headerRenderer** | string<br>*or*<br>function(rows)<br>*or*<br>false (bool) | What to display as the context menu's header.<br><br>Can be a static string or a function of the rows selected.<br><br>Set to `false` to skip rendering a header.                                                                      | `''`      |
 | **headerIsFollowedByDivider** | bool | Controls if a divider is automatically added next to the header. (Ignored, if header is set to `false`.)                                                                      | `false`     |
-
 | **showStaticOptions** | bool | Whether or not to display `static` items in the context menu                                                                      | `false`      |
 
 ## options.buttonList

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datatables-contextual-actions",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "A DataTables javascript plugin for adding contextual options (\"right-click\" menu, as well as a matching button-bar) to one or many selected rows.",
   "main": "dist/dataTables.contextualActions.min.js",
   "directories": {

--- a/src/dataTables.contextualActions.js
+++ b/src/dataTables.contextualActions.js
@@ -332,11 +332,23 @@ jQuery.fn.dataTable.Api.register('contextualActions()', function (options) {
 
 			// Handle dividers
 			if (item.type === ITEMTYPE.DIVIDER) {
-				// Only render dividers if they aren't first, last, or beside a previous divider
+
+				// Ensure the divider is needed and actually divides items
+				// This is because dividers may be ideal within the button bar but not make sense in a context menu
 				if (
-					i > 0 && // first
-					i !== items.length - 1 && // last
-					items[i - 1].type !== ITEMTYPE.DIVIDER // previous wasn't also a divider
+					i > 0 && // the divider isn't first
+					i !== items.length - 1 && // the divider isn't last
+					items[i - 1].type !== ITEMTYPE.DIVIDER && // the previous item wasn't also a divider
+					// the previous item isn't a static item not shown in the context menu which is preceded itself by a divider
+					!(
+						// previous item is static and hidden in context menu
+						(items[i - 1].type === ITEMTYPE.STATIC && !options.contextMenu.showStaticOptions)
+						&&
+						// and the item before it was a divider
+						(
+							i >= 2 && items[i - 2].type === ITEMTYPE.DIVIDER
+						)
+					) // previous wasn't static but invisible and the one before that was a divider
 				) {
 					menu.append('<div class="dropdown-divider"></div>');
 				}


### PR DESCRIPTION
1) A newline in the readme was causing formatting issues in some renderers
2) The now-possibly-hidden header renderer, when hidden and sitting next to a hidden static menu option, was resulting in an erroneous menu divider